### PR TITLE
using TMUX_BIN

### DIFF
--- a/mouse-swipe.tmux
+++ b/mouse-swipe.tmux
@@ -7,7 +7,7 @@
 #
 #   Part of https://github.com/jaclu/tmux-mouse-swipe
 #
-#   Version: 1.3.1 2022-04-15
+#   Version: 1.3.2 2022-09-15
 #
 
 CURRENT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -23,7 +23,7 @@ swipe_script="$SCRIPTS_DIR/handle_mouse_swipe.sh"
 get_tmux_option() {
     gtm_option=$1
     gtm_default=$2
-    gtm_value=$(tmux show-option -gqv "$gtm_option")
+    gtm_value=$($TMUX_BIN show-option -gqv "$gtm_option")
     if [ -z "$gtm_value" ]; then
         echo "$gtm_default"
     else
@@ -86,7 +86,7 @@ log_it "use_notes=[$use_notes]"
 #  This normally triggers the right click default popups, they don't
 #  play well when we use right clicks for other purposes.
 #
-tmux unbind-key -n MouseDown3Pane
+$TMUX_BIN unbind-key -n MouseDown3Pane
 
 
 #
@@ -102,7 +102,7 @@ tmux unbind-key -n MouseDown3Pane
 #  Either way now it is switched to a -g both here and in the handler script,
 #  and this issue is gone!
 #
-tmux set-option -g @mouse_drag_status 'untested'
+$TMUX_BIN set-option -g @mouse_drag_status 'untested'
 
 
 #
@@ -110,9 +110,9 @@ tmux set-option -g @mouse_drag_status 'untested'
 #   man tmux - MOUSE SUPPORT section. to find what best matches your needs.
 #
 if [ "$use_notes" -eq 1 ]; then
-    tmux bind-key -N "$plugin_name drag start" -n MouseDrag3Pane    run "$swipe_script down '#{mouse_x}' '#{mouse_y}'"
-    tmux bind-key -N "$plugin_name drag stop" -n MouseDragEnd3Pane run "$swipe_script up   '#{mouse_x}' '#{mouse_y}'"
+    $TMUX_BIN bind-key -N "$plugin_name drag start" -n MouseDrag3Pane    run "$swipe_script down '#{mouse_x}' '#{mouse_y}'"
+    $TMUX_BIN bind-key -N "$plugin_name drag stop" -n MouseDragEnd3Pane run "$swipe_script up   '#{mouse_x}' '#{mouse_y}'"
 else
-    tmux bind-key -n MouseDrag3Pane    run "$swipe_script down '#{mouse_x}' '#{mouse_y}'"
-    tmux bind-key -n MouseDragEnd3Pane run "$swipe_script up   '#{mouse_x}' '#{mouse_y}'"
+    $TMUX_BIN bind-key -n MouseDrag3Pane    run "$swipe_script down '#{mouse_x}' '#{mouse_y}'"
+    $TMUX_BIN bind-key -n MouseDragEnd3Pane run "$swipe_script up   '#{mouse_x}' '#{mouse_y}'"
 fi

--- a/scripts/handle_mouse_swipe.sh
+++ b/scripts/handle_mouse_swipe.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-__version="1.5.1 2022-04-13"
+__version="1.5.2 2022-09-15"
 #
 #   Copyright (c) 2021,2022: Jacob.Lundqvist@gmail.com
 #   License: MIT
@@ -67,7 +67,7 @@ debug() {
     #
     #  shellcheck disable=SC2154
     [ "$log_lvl" -le "$debug_lvl" ] && log_it "{$log_lvl} $msg"
-    [ "$log_lvl" -eq 0 ]  && tmux display "$msg"
+    [ "$log_lvl" -eq 0 ]  && $TMUX_BIN display "$msg"
 }
 
 
@@ -141,7 +141,7 @@ drag_status_set() {
     drag_status="$status"
     if [ "$push_it" = "1" ]; then
         debug 4 "pushing status to tmux: $status"
-        tmux set-option -g @mouse_drag_status "$status"
+        $TMUX_BIN set-option -g @mouse_drag_status "$status"
     fi
 }
 
@@ -154,7 +154,7 @@ drag_status_get() {
         debug 4 "< reading $drag_stat_cache_file, found: $drag_status"
     else
         drag_status="untested"
-        ds_prel="$(tmux show -g @mouse_drag_status)"
+        ds_prel="$($TMUX_BIN show -g @mouse_drag_status)"
         drag_status="$(echo "$ds_prel" | cut -d' ' -f 2)"
         debug 4 "< drag_status_get: prel[$ds_prel] status[$drag_status]"
     fi
@@ -181,7 +181,7 @@ incompatible_env() {
 
 env_check() {
     debug 3 "env_check()"
-    vers="$(tmux -V | cut -d' ' -f 2)"
+    vers="$($TMUX_BIN -V | cut -d' ' -f 2)"
 
     if [ "$drag_status" = "$env_incompatible" ]; then
         debug 0 "$plugin_name ERROR: env incompatible"
@@ -199,7 +199,7 @@ env_check() {
             incompatible_env "vers < 3.0 no mouse_x / mouse_y support, so this utility can not work properly"
         fi
         if  expr "'$vers" \< "'$min_version"   > /dev/null ; then
-            incompatible_env "tmux $vers < min vers: $min_version"
+            incompatible_env "$TMUX_BIN $vers < min vers: $min_version"
             clear_status
             exit 0
         fi
@@ -235,30 +235,30 @@ handle_up() {
         debug 0 "$plugin_name: Did not detect any movement!"
 
     elif [ "$abs_x" -gt "$abs_y" ] ; then    # Horizontal swipe
-        if [ "$(tmux list-windows -F '#{window_id}' | wc -l)" -lt 2 ]; then
+        if [ "$($TMUX_BIN list-windows -F '#{window_id}' | wc -l)" -lt 2 ]; then
             debug 0 "$plugin_name: Only one window, can't switch!"
             return
         elif [ "$mouse_x" -gt "$org_mouse_x" ]; then
             debug 1 "will switch to the right"
-            [ "$benchmarking" -eq 0 ] && tmux select-window -n
+            [ "$benchmarking" -eq 0 ] && $TMUX_BIN select-window -n
         else
             debug 1 "will switch to the left"
-            [ "$benchmarking" -eq 0 ] && tmux select-window -p
+            [ "$benchmarking" -eq 0 ] && $TMUX_BIN select-window -p
         fi
 
     elif [ "$abs_x" -eq "$abs_y" ] ; then    # Unclear direction
         debug 0 "$plugin_name: equal horizontal and vertical movement, direction unclear!"
 
     else                                     # Vertical swipe
-        if [ "$(tmux list-sessions | wc -l)" -lt "2" ]; then
+        if [ "$($TMUX_BIN list-sessions | wc -l)" -lt "2" ]; then
             debug 0 "$plugin_name: Only one session, can't switch!"
             return
         elif [ "$mouse_y" -gt "$org_mouse_y" ]; then
             debug 1 "will switch to next session"
-            [ "$benchmarking" -eq 0 ] && tmux switch-client -n
+            [ "$benchmarking" -eq 0 ] && $TMUX_BIN switch-client -n
         else
             debug 1 "will switch to previous session"
-            [ "$benchmarking" -eq 0 ] && tmux switch-client -p
+            [ "$benchmarking" -eq 0 ] && $TMUX_BIN switch-client -p
         fi
     fi
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -21,6 +21,17 @@ plugin_name="tmux-mouse-swipe"
 
 
 #
+#  I use an env var TMUX_BIN to point at the current tmux, defined in my
+#  tmux.conf, in order to pick the version matching the server running.
+#  This is needed when checking backwards compatability with various versions.
+#  If not found, it is set to whatever is in path, so should have no negative
+#  impact. In all calls to tmux I use $TMUX_BIN instead in the rest of this
+#  plugin.
+#
+[ -z "$TMUX_BIN" ] && TMUX_BIN="tmux"
+
+
+#
 #  If log_file is empty or undefined, no logging will occur,
 #  so comment it out for normal usage.
 #


### PR DESCRIPTION
In order to be able to test various versions of tmux for compatibility with plugins, I used ASDF.
This has the drawback of using ~/.asdf/shims/tmux thus not allowing the path to tmux itself to identify what tmux to run, so I have set up my tmux.conf to identify the actual tmux in that case. When using ASDF the actual path to tmux (example: ~/.asdf/installs/tmux/2.8/bin/tmux) is identified and stored in the env variable TMUX_BIN

Using $TMUX_BIN whenever the plugin needs to access tmux from the shell, ensures that the plugin uses the tmux associated with the running session. This makes my testing much more convenient since I don't have to kill my main tmux each time I want to test a specific version, I just run a separate tmux under the version being tested.
This should not have any impact if TMUX_BIN is not used, since then it defaults to just being 'tmux'