### PR TITLE
Handle drag end without recorded drag start gracefully

### DIFF
--- a/scripts/handle_mouse_swipe.sh
+++ b/scripts/handle_mouse_swipe.sh
@@ -26,8 +26,15 @@ drag_start_get() {
     if [ -f "$f_drag_stat" ]; then
         drag_start="$(cat "$f_drag_stat")"
     else
-        echo "ERROR! No drag start file: $f_drag_stat"
-        exit 1
+        #
+        #  A drag end can arrive without a recorded drag start, for example
+        #  when the drag began on the status line or a pane border (locations
+        #  this plugin does not bind), or when the cache file was cleared by
+        #  a config reload whilst a drag was in progress. There is nothing
+        #  to act upon, so just ignore it.
+        #
+        log_it 1 "drag end without drag start - ignoring"
+        exit 0
     fi
     org_mouse_x="${drag_start%%-*}"
     org_mouse_y="${drag_start#*-}"


### PR DESCRIPTION
## Problem

`MouseDragEnd3Pane` can fire without a preceding `MouseDrag3Pane`, which makes the plugin print an error into the client:

```
ERROR! No drag start file: /var/folders/.../drag_status_cache-501
'/path/to/handle_mouse_swipe.sh up '7' '0'' returned 1
```

This happens in normal use, for example when:

- the right-button drag starts on the status line or a pane border (locations the plugin does not bind), and is released over a pane
- the drag cache file is cleared mid-drag by a config reload (plugin init calls `clear_status`) or by a second tmux server sharing the same `$TMPDIR` cache file

## Fix

A drag end without a recorded drag start simply means there is nothing to act on, so `drag_start_get()` now logs it at level 1 and exits 0 instead of printing an error and exiting 1.

## Testing

- `handle_mouse_swipe.sh up 7 0` with no cache file: exits 0, silent (previously exit 1 + error)
- normal swipe on a test server (`down 5 5` then `up 15 5` with two windows): still switches window as expected
- shellcheck passes